### PR TITLE
CAN-FD, choose smallest DLC that fits message. Related bugfixes.

### DIFF
--- a/src/isotp/mod.rs
+++ b/src/isotp/mod.rs
@@ -127,17 +127,17 @@ impl<'a> IsoTPAdapter<'a> {
         let offset = self.config.ext_address.is_some() as usize;
         let len = data.len() + offset;
 
-        // Pad to next valid DLC
+        // Pad to at least 8 bytes if padding is enabled
+        if let Some(padding) = self.config.padding {
+            let padding_len = CAN_MAX_DLEN - len; // Offset for extended address is already accounted for
+            data.extend(std::iter::repeat(padding).take(padding_len));
+        }
+
+        // Pad to next valid DLC for CAN-FD
         if !DLC_TO_LEN.contains(&len) {
             let idx = DLC_TO_LEN.iter().position(|&x| x > data.len()).unwrap();
             let padding = self.config.padding.unwrap_or(DEFAULT_PADDING_BYTE);
             let padding_len = DLC_TO_LEN[idx] - len;
-            data.extend(std::iter::repeat(padding).take(padding_len));
-        }
-
-        // Pad to full length if padding is enabled
-        if let Some(padding) = self.config.padding {
-            let padding_len = self.max_can_data_length() - len;
             data.extend(std::iter::repeat(padding).take(padding_len));
         }
     }
@@ -160,7 +160,7 @@ impl<'a> IsoTPAdapter<'a> {
     /// Maximum data length for a CAN frame based on the current config
     fn max_can_data_length(&self) -> usize {
         match self.config.max_dlen {
-            Some(dlen) => dlen,
+            Some(dlen) => dlen - self.offset(),
             None => {
                 if self.config.fd {
                     self.can_fd_max_dlen()

--- a/src/isotp/mod.rs
+++ b/src/isotp/mod.rs
@@ -129,8 +129,10 @@ impl<'a> IsoTPAdapter<'a> {
 
         // Pad to at least 8 bytes if padding is enabled
         if let Some(padding) = self.config.padding {
-            let padding_len = CAN_MAX_DLEN - len; // Offset for extended address is already accounted for
-            data.extend(std::iter::repeat(padding).take(padding_len));
+            if len < CAN_MAX_DLEN {
+                let padding_len = CAN_MAX_DLEN - len; // Offset for extended address is already accounted for
+                data.extend(std::iter::repeat(padding).take(padding_len));
+            }
         }
 
         // Pad to next valid DLC for CAN-FD
@@ -208,7 +210,7 @@ impl<'a> IsoTPAdapter<'a> {
     pub async fn send_single_frame(&self, data: &[u8]) -> Result<()> {
         let mut buf;
 
-        if data.len() < 0xf {
+        if data.len() < 0x8 {
             // Len fits in single nibble
             buf = vec![FrameType::Single as u8 | data.len() as u8];
         } else {

--- a/tests/isotp_tests.rs
+++ b/tests/isotp_tests.rs
@@ -163,6 +163,9 @@ async fn isotp_test_fd() {
         ..Default::default()
     };
 
+    // Single frame with some padding to reach next DLC
+    isotp_test_echo(8, config).await;
+
     // Single frame escape
     isotp_test_echo(62, config).await;
 
@@ -170,6 +173,7 @@ async fn isotp_test_fd() {
     isotp_test_echo(50, config).await;
 
     // Multiple frames
+    isotp_test_echo(218, config).await;
     isotp_test_echo(256, config).await;
 
     // First frame escape


### PR DESCRIPTION
 - Resolves #70 
 - Fixes bug in CAN-FD ISO-TP Single Frame escape sequence
   - Escape sequence should be used when `CAN_DL > 8`, not when it doesn't fit inside the nibble
 - Fix bug where `max_dlen` would be exceeded when extended addressing was used