### PR TITLE
Lazy-load vxlapi64 DLL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,7 @@ dependencies = [
  "futures",
  "hex",
  "libc",
+ "libloading",
  "rusb",
  "serde",
  "serial_test",
@@ -181,12 +182,12 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -304,11 +305,11 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "home"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -949,6 +950,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -959,11 +966,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-targets 0.53.3",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -988,7 +995,7 @@ version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ all-adapters = ["default-adapters", "vector-xl"]
 serde = ["dep:serde"]
 
 # adapters
-vector-xl = ["dep:bindgen"]
+vector-xl = ["dep:bindgen", "dep:libloading"]
 panda = []
 socketcan = []
 
@@ -43,6 +43,9 @@ tracing = "0.1"
 [target.'cfg(target_os = "linux")'.dependencies]
 socket2 = "0.6.0"
 libc = "0.2.154"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+libloading = { version = "0.8", optional = true }
 
 [dev-dependencies]
 futures = "0.3.30"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,9 @@
 //! Contains the main error type for the library.
+
 use thiserror::Error;
 
 /// The main error type for the library. Each module has it's own error type that is contained by this error.
-#[derive(Error, Debug, PartialEq, Clone)]
+#[derive(Error, Debug, Clone)]
 pub enum Error {
     #[error("Not Found")]
     NotFound,
@@ -26,6 +27,10 @@ pub enum Error {
     #[error(transparent)]
     VectorError(#[from] crate::vector::Error),
 
+    #[cfg(all(target_os = "windows", feature = "vector-xl"))]
+    #[error("Error loading DLL: {0}")]
+    Libloading(std::sync::Arc<libloading::Error>),
+
     #[cfg(feature = "panda")]
     #[error(transparent)]
     PandaError(#[from] crate::panda::Error),
@@ -34,5 +39,12 @@ pub enum Error {
 impl From<tokio_stream::Elapsed> for Error {
     fn from(_: tokio_stream::Elapsed) -> Error {
         Error::Timeout
+    }
+}
+
+#[cfg(all(target_os = "windows", feature = "vector-xl"))]
+impl From<libloading::Error> for Error {
+    fn from(val: libloading::Error) -> Self {
+        Self::Libloading(std::sync::Arc::new(val))
     }
 }

--- a/src/panda/usb_protocol.rs
+++ b/src/panda/usb_protocol.rs
@@ -208,7 +208,7 @@ mod tests {
             fd: false,
         }];
         let r = pack_can_buffer(&frames);
-        assert_eq!(r, Err(Error::MalformedFrame));
+        assert!(matches!(r, Err(Error::MalformedFrame)));
     }
 
     #[test]
@@ -221,6 +221,6 @@ mod tests {
             fd: false,
         }];
         let r = pack_can_buffer(&frames);
-        assert_eq!(r, Err(Error::MalformedFrame));
+        assert!(matches!(r, Err(Error::MalformedFrame)));
     }
 }

--- a/src/vector/bindings.rs
+++ b/src/vector/bindings.rs
@@ -5,3 +5,6 @@
 #![allow(dead_code)]
 #![allow(unused_imports)]
 include!(concat!(env!("OUT_DIR"), "/vxlapi_bindings.rs"));
+
+unsafe impl Sync for Xl {}
+unsafe impl Send for Xl {}

--- a/tests/uds_tests.rs
+++ b/tests/uds_tests.rs
@@ -6,6 +6,7 @@ use automotive::uds::Error as UDSError;
 use automotive::uds::NegativeResponseCode;
 use automotive::uds::UDSClient;
 use automotive::StreamExt;
+use automotive::Error;
 use std::process::{Child, Command};
 
 static VECU_STARTUP_TIMEOUT_MS: u64 = 10000;
@@ -50,5 +51,5 @@ async fn uds_test_sids() {
     let resp = uds.diagnostic_session_control(0x2).await;
     let security_access_denied =
         UDSError::NegativeResponse(NegativeResponseCode::SecurityAccessDenied);
-    assert_eq!(resp, Err(security_access_denied.into()));
+    assert!(matches!(resp, Err(Error::UDSError(e)) if e == security_access_denied));
 }

--- a/third_party/vector/wrapper.h
+++ b/third_party/vector/wrapper.h
@@ -1,2 +1,3 @@
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include "vxlapi.h"


### PR DESCRIPTION
The use-case is building a program that has Vector support, but doesn't require the user to have the DLL installed if they're not using any Vector functionality (e.g. because they only use panda).

The simple solution would've been to ship the DLL with your software (which I believe to be the standard approach for PCAN), but that is explicitly forbidden by the license:

> The DLLs (dynamic linked libraries) of the XL Driver Library may not
> be distributed solely or as part of any programs without a previous
> written individual agreement with Vector. For such individual use
> cases, please contact support@vector.com.

Given the above, I also wonder whether the dll should be removed from this repository, but I will leave that up to the maintainer's discretion.

I assume that vxlapi64 is thread-safe (their factsheet suggests that), but they do not explicitly confirm nor deny this in any of their documentation.

The build script had to be modified to only generate rust code for the parts of the header file that are actually used, to prevent build times in the minutes to hours range.

The Error type now no longer implements PartialEq, since the libloading Error type doesn't, and it's not common for error types in general.