### PR TITLE
Add PCAN-USB adapter for macOS (MacCAN PCBUSB)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/I-CAN-hack/automotive"
 default = []
 all = ["all-adapters", "serde"]
 default-adapters = ["panda", "socketcan"]
-all-adapters = ["default-adapters", "vector-xl", "j2534"]
+all-adapters = ["default-adapters", "vector-xl", "j2534", "pcan"]
 serde = ["dep:serde"]
 
 # adapters
@@ -21,10 +21,12 @@ vector-xl = ["dep:bindgen", "dep:libloading"]
 j2534 = ["dep:libloading", "dep:winreg"]
 panda = ["dep:rusb"]
 socketcan = ["dep:libc", "dep:socket2"]
+pcan = []
 
 # adapter tests
 test-j2534 = ["j2534"]
 test-panda = ["panda"]
+test-pcan = ["pcan"]
 test-socketcan = ["socketcan"]
 test-vcan = ["socketcan"]
 test-vector = ["vector-xl"]

--- a/build.rs
+++ b/build.rs
@@ -54,18 +54,43 @@ fn build_vxlapi() {
         .expect("Couldn't write bindings!");
 }
 
+fn link_pcbusb() {
+    // The MacCAN PCBUSB library ships as `libPCBUSB.dylib` in one of the
+    // system-wide lib dirs. Hint the linker at both Intel (/usr/local) and
+    // Apple Silicon (/opt/homebrew) prefixes.
+    //
+    // The dylib's install name is `@rpath/libPCBUSB.<ver>.dylib`, so we also
+    // emit matching rpaths. `rustc-link-arg` applies to examples, tests, and
+    // in-crate binaries — downstream consumers still need to add their own
+    // rpath (mirroring the "distribute the DLL" model the Vector and J2534
+    // adapters use on Windows).
+    for dir in ["/usr/local/lib", "/opt/homebrew/lib"] {
+        if std::path::Path::new(dir).exists() {
+            println!("cargo:rustc-link-search=native={}", dir);
+            println!("cargo:rustc-link-arg=-Wl,-rpath,{}", dir);
+        }
+    }
+    println!("cargo:rustc-link-lib=dylib=PCBUSB");
+}
+
 fn main() {
     // Re-run if these change (helps with incremental builds / switching targets).
     println!("cargo:rerun-if-env-changed=TARGET");
     println!("cargo:rerun-if-env-changed=HOST");
     println!("cargo:rerun-if-env-changed=CARGO_CFG_TARGET_OS");
     println!("cargo:rerun-if-env-changed=CARGO_FEATURE_VECTOR_XL");
+    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_PCAN");
 
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
     let vector_xl_enabled = env::var_os("CARGO_FEATURE_VECTOR_XL").is_some();
+    let pcan_enabled = env::var_os("CARGO_FEATURE_PCAN").is_some();
 
     if target_os == "windows" && vector_xl_enabled {
         #[cfg(feature = "vector-xl")]
         build_vxlapi();
+    }
+
+    if target_os == "macos" && pcan_enabled {
+        link_pcbusb();
     }
 }

--- a/src/can/adapter.rs
+++ b/src/can/adapter.rs
@@ -58,5 +58,24 @@ pub fn get_adapter() -> Result<crate::can::AsyncCanAdapter, crate::error::Error>
         };
     }
 
+    #[cfg(all(target_os = "macos", feature = "pcan"))]
+    {
+        let bitrate_cfg = crate::can::bitrate::BitrateBuilder::new::<crate::pcan::Pcan>()
+            .bitrate(500_000)
+            .sample_point(0.8)
+            .sjw(1)
+            .data_bitrate(2_000_000)
+            .data_sample_point(0.8)
+            .data_sjw(1)
+            .build()
+            .unwrap();
+
+        for channel_idx in 0..8 {
+            if let Ok(adapter) = crate::pcan::Pcan::new_async(channel_idx, bitrate_cfg) {
+                return Ok(adapter);
+            }
+        }
+    }
+
     Err(crate::error::Error::NotFound)
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -42,6 +42,10 @@ pub enum Error {
     #[cfg(feature = "panda")]
     #[error(transparent)]
     PandaError(#[from] crate::panda::Error),
+
+    #[cfg(all(target_os = "macos", feature = "pcan"))]
+    #[error(transparent)]
+    PcanError(#[from] crate::pcan::Error),
 }
 
 impl From<tokio_stream::Elapsed> for Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@
 //!  - comma.ai panda (all platforms using [rusb](https://crates.io/crates/rusb), enable with the `panda` feature)
 //!  - J2534 PassThru Devices (Windows only, enable with the `j2534` feature)
 //!  - Vector Devices (Windows x64 only, enable with the `vector-xl` feature)
+//!  - PEAK PCAN-USB / PCAN-USB FD (macOS only via [PCBUSB](https://github.com/mac-can/PCBUSB-Library), enable with the `pcan` feature)
 //!
 //! Adapter support is opt-in. The default feature set does not enable any hardware adapters.
 //!
@@ -67,6 +68,7 @@
 //!    - The panda does not retry frames that are not ACKed, and drops them instead. This can cause panics in some internal parts of the library when frames are dropped. [panda#1922](https://github.com/commaai/panda/issues/1922) tracks this issue.
 //!  - J2534 PassThru Devices are supported through the `j2534` feature. The library provides `J2534CanAdapter` for raw CAN access, and `J2534NativeIsoTpTransport` to offload ISO-TP framing, flow-control, and timing to the adapter. It is recommended to use `J2534CanAdapter` unless you have specific speed or latency requirements.
 //!  - Vector Devices are supported through the Vector XL Driver Library, and support can be enabled using the `vector-xl` feature. Make sure to distribute `vxlapi64.dll` alongside your application.
+//!  - PEAK PCAN devices on macOS are supported through the [PCBUSB](https://github.com/mac-can/PCBUSB-Library) library, a macOS port of PEAK's PCAN-Basic API. Install the `libPCBUSB.dylib` from the MacCAN project (for example at `/usr/local/lib/libPCBUSB.dylib`) and enable the `pcan` feature. The adapter supports both classic CAN (`CAN_Initialize`) and CAN-FD (`CAN_InitializeFD`). On Linux, PEAK devices should be used through SocketCAN instead.
 //!
 //!
 //! ### Implementing a New Adapter
@@ -105,3 +107,7 @@ pub mod j2534;
 #[cfg(feature = "panda")]
 #[cfg_attr(docsrs, doc(cfg(feature = "panda")))]
 pub mod panda;
+
+#[cfg(all(target_os = "macos", feature = "pcan"))]
+#[cfg_attr(docsrs, doc(cfg(all(target_os = "macos", feature = "pcan"))))]
+pub mod pcan;

--- a/src/pcan/error.rs
+++ b/src/pcan/error.rs
@@ -1,0 +1,50 @@
+//! PCAN adapter error types.
+
+use std::ffi::{c_char, CStr};
+use thiserror::Error;
+
+/// PCAN-Basic status code wrapped with an English description.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PcanStatus {
+    /// Raw `TPCANStatus` value returned by PCBUSB.
+    pub code: u32,
+    /// Human-readable description as returned by `CAN_GetErrorText`.
+    pub message: String,
+}
+
+impl std::fmt::Display for PcanStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "0x{:x} ({})", self.code, self.message)
+    }
+}
+
+impl PcanStatus {
+    /// Construct a [`PcanStatus`] from a raw PCAN-Basic status code, filling in
+    /// the human-readable message via `CAN_GetErrorText`.
+    pub fn from_code(code: u32) -> Self {
+        let mut buf = [0i8; 256];
+        let rc =
+            unsafe { super::sys::CAN_GetErrorText(code, 0x09, buf.as_mut_ptr() as *mut c_char) };
+        let message = if rc == super::sys::PCAN_ERROR_OK {
+            unsafe { CStr::from_ptr(buf.as_ptr() as *const c_char) }
+                .to_string_lossy()
+                .into_owned()
+        } else {
+            String::new()
+        };
+        PcanStatus { code, message }
+    }
+}
+
+/// Errors surfaced by the PCAN adapter.
+#[derive(Error, Debug, Clone)]
+pub enum Error {
+    #[error("PCAN initialization failed on channel 0x{channel:02x}: {status}")]
+    Initialize { channel: u16, status: PcanStatus },
+
+    #[error("PCAN reports an unsupported bitrate configuration: {0}")]
+    UnsupportedBitrate(String),
+
+    #[error("PCAN adapter returned error: {0}")]
+    Driver(PcanStatus),
+}

--- a/src/pcan/mod.rs
+++ b/src/pcan/mod.rs
@@ -1,0 +1,389 @@
+//! PEAK PCAN adapter support (macOS via the MacCAN PCBUSB library).
+//!
+//! This adapter talks to PEAK's USB CAN interfaces (PCAN-USB and PCAN-USB FD)
+//! through UV Software's [PCBUSB library][pcbusb] — a macOS port of PEAK's
+//! PCAN-Basic API. PCBUSB must be installed on the host; pre-built universal
+//! binaries ship the dylib as `/usr/local/lib/libPCBUSB.dylib`.
+//!
+//! Both classic CAN and CAN-FD are supported:
+//! - If the [`BitrateConfig`] has no data phase, the adapter opens the channel
+//!   with `CAN_Initialize` and a validated BTR0BTR1 constant derived from the
+//!   nominal bitrate.
+//! - If the config includes a data phase, the adapter opens the channel with
+//!   `CAN_InitializeFD` and a bitrate string built from the resolved timing.
+//!
+//! PCBUSB does not expose a reliable hardware loopback stream, so outgoing
+//! frames are synthesised back into the receive queue on successful transmit,
+//! mirroring the emulated-ACK path the SocketCAN adapter uses when `IFF_ECHO`
+//! is unavailable.
+//!
+//! [pcbusb]: https://github.com/mac-can/PCBUSB-Library
+
+mod error;
+mod sys;
+
+pub use error::{Error, PcanStatus};
+
+use std::collections::VecDeque;
+use std::ffi::{c_void, CString};
+
+use tracing::{debug, info, warn};
+
+use crate::can::bitrate::{AdapterBitTiming, AdapterTimingConst, BitTimingConst, BitrateConfig};
+use crate::can::{AsyncCanAdapter, CanAdapter, Frame, Identifier, DLC_TO_LEN};
+use crate::Result;
+
+/// PCAN-USB FD controller runs on a configurable clock; 80 MHz gives the
+/// widest tseg range and is supported by every PCAN-USB FD device.
+const DEFAULT_FD_CLOCK_MHZ: u32 = 80;
+
+/// Hardware bit-timing limits used by [`crate::can::bitrate::BitrateBuilder`]
+/// when solving timing for a PCAN-USB FD channel.
+pub const PCAN_USB_FD_TIMING_CONST: AdapterTimingConst = AdapterTimingConst {
+    nominal: BitTimingConst {
+        clock_hz: 80_000_000,
+        tseg1_min: 1,
+        tseg1_max: 256,
+        tseg2_min: 1,
+        tseg2_max: 128,
+        sjw_max: 128,
+        brp_min: 1,
+        brp_max: 1024,
+        brp_inc: 1,
+    },
+    data: Some(BitTimingConst {
+        clock_hz: 80_000_000,
+        tseg1_min: 1,
+        tseg1_max: 32,
+        tseg2_min: 1,
+        tseg2_max: 16,
+        sjw_max: 16,
+        brp_min: 1,
+        brp_max: 1024,
+        brp_inc: 1,
+    }),
+};
+
+/// Blocking PCAN-USB adapter implementing [`CanAdapter`].
+pub struct Pcan {
+    channel: sys::TPCANHandle,
+    /// Synthetic loopback frames queued on successful transmit.
+    loopback_queue: VecDeque<Frame>,
+}
+
+impl Pcan {
+    /// Convenience wrapper that opens the adapter and hands it to
+    /// [`AsyncCanAdapter::new`].
+    ///
+    /// `channel_idx` is the zero-based PCAN-USB channel index
+    /// (`0 -> PCAN_USBBUS1`, `7 -> PCAN_USBBUS8`).
+    pub fn new_async(channel_idx: usize, bitrate_cfg: BitrateConfig) -> Result<AsyncCanAdapter> {
+        Ok(AsyncCanAdapter::new(Self::new(channel_idx, bitrate_cfg)?))
+    }
+
+    /// Open a specific PCAN-USB channel with the provided bitrate config.
+    ///
+    /// Returns [`crate::Error::NotFound`] if the channel is not available,
+    /// [`Error::UnsupportedBitrate`] if the bitrate cannot be mapped to a
+    /// PCAN-Basic configuration, and [`Error::Initialize`] for driver-level
+    /// initialization failures.
+    pub fn new(channel_idx: usize, bitrate_cfg: BitrateConfig) -> Result<Pcan> {
+        if channel_idx > (sys::PCAN_USBBUS_LAST - sys::PCAN_USBBUS1) as usize {
+            return Err(crate::Error::NotSupported);
+        }
+        let channel = sys::PCAN_USBBUS1 + channel_idx as sys::TPCANHandle;
+
+        let status = initialize_channel(channel, &bitrate_cfg)?;
+
+        if status == sys::PCAN_ERROR_OK {
+            let fd = bitrate_cfg.data.is_some();
+            info!(
+                channel = format_args!("0x{:02x}", channel),
+                fd, "PCAN-USB channel opened"
+            );
+            configure_defaults(channel);
+            Ok(Pcan {
+                channel,
+                loopback_queue: VecDeque::new(),
+            })
+        } else if matches!(
+            status,
+            sys::PCAN_ERROR_QRCVEMPTY | 0x00400 /* PCAN_ERROR_HWINUSE */
+        ) || status == 0x00200
+        /* PCAN_ERROR_NODRIVER */
+        {
+            Err(crate::Error::NotFound)
+        } else {
+            Err(Error::Initialize {
+                channel,
+                status: PcanStatus::from_code(status),
+            }
+            .into())
+        }
+    }
+
+    /// Raw PCAN handle of the currently opened channel.
+    pub fn channel(&self) -> u16 {
+        self.channel
+    }
+
+    /// Read the PCAN controller status (`CAN_GetStatus`) as a
+    /// [`PcanStatus`]. Useful for diagnosing bus-off and error-passive states.
+    pub fn controller_status(&self) -> PcanStatus {
+        let code = unsafe { sys::CAN_GetStatus(self.channel) };
+        PcanStatus::from_code(code)
+    }
+}
+
+impl Drop for Pcan {
+    fn drop(&mut self) {
+        unsafe {
+            sys::CAN_Uninitialize(self.channel);
+        }
+    }
+}
+
+impl CanAdapter for Pcan {
+    fn send(&mut self, frames: &mut VecDeque<Frame>) -> Result<()> {
+        while let Some(frame) = frames.pop_front() {
+            let msg = match build_msg(&frame) {
+                Ok(msg) => msg,
+                Err(err) => {
+                    frames.push_front(frame);
+                    return Err(err);
+                }
+            };
+
+            let status = unsafe { sys::CAN_WriteFD(self.channel, &msg) };
+            if status == sys::PCAN_ERROR_OK {
+                let mut echo = frame;
+                echo.loopback = true;
+                self.loopback_queue.push_back(echo);
+                continue;
+            }
+
+            if status & sys::PCAN_ERROR_QXMTFULL != 0 {
+                // Hardware TX queue is full — retry on the next poll.
+                frames.push_front(frame);
+                break;
+            }
+
+            warn!(
+                status = %PcanStatus::from_code(status),
+                "PCAN: CAN_WriteFD failed"
+            );
+            frames.push_front(frame);
+            return Err(Error::Driver(PcanStatus::from_code(status)).into());
+        }
+        Ok(())
+    }
+
+    fn recv(&mut self) -> Result<Vec<Frame>> {
+        let mut frames = Vec::new();
+        loop {
+            let mut msg = sys::TPCANMsgFD::zeroed();
+            let mut ts: u64 = 0;
+            let status = unsafe { sys::CAN_ReadFD(self.channel, &mut msg, &mut ts) };
+
+            if status == sys::PCAN_ERROR_QRCVEMPTY {
+                break;
+            }
+
+            if status != sys::PCAN_ERROR_OK {
+                if status & !sys::PCAN_ERROR_QRCVEMPTY != 0 {
+                    debug!(
+                        status = %PcanStatus::from_code(status),
+                        "PCAN: CAN_ReadFD non-ok status"
+                    );
+                }
+                break;
+            }
+
+            if msg.msg_type
+                & (sys::PCAN_MESSAGE_STATUS
+                    | sys::PCAN_MESSAGE_ERRFRAME
+                    | sys::PCAN_MESSAGE_RTR
+                    | sys::PCAN_MESSAGE_ECHO)
+                != 0
+            {
+                continue;
+            }
+
+            let id = if msg.msg_type & sys::PCAN_MESSAGE_EXTENDED != 0 {
+                Identifier::Extended(msg.id)
+            } else {
+                Identifier::Standard(msg.id)
+            };
+
+            let dlc = msg.dlc as usize;
+            if dlc >= DLC_TO_LEN.len() {
+                warn!(dlc = msg.dlc, "PCAN: bogus DLC, skipping frame");
+                continue;
+            }
+            let len = DLC_TO_LEN[dlc];
+
+            frames.push(Frame {
+                bus: 0,
+                id,
+                data: msg.data[..len].to_vec(),
+                loopback: false,
+                fd: msg.msg_type & sys::PCAN_MESSAGE_FD != 0,
+            });
+        }
+
+        frames.extend(self.loopback_queue.drain(..));
+        Ok(frames)
+    }
+
+    fn timing_const() -> AdapterTimingConst
+    where
+        Self: Sized,
+    {
+        PCAN_USB_FD_TIMING_CONST
+    }
+}
+
+fn initialize_channel(
+    channel: sys::TPCANHandle,
+    bitrate_cfg: &BitrateConfig,
+) -> Result<sys::TPCANStatus> {
+    if let Some(data) = bitrate_cfg.data {
+        let bitrate = build_bitrate_string(&bitrate_cfg.nominal, &data);
+        let c_bitrate = CString::new(bitrate.clone())
+            .map_err(|_| Error::UnsupportedBitrate(bitrate.clone()))?;
+        Ok(unsafe { sys::CAN_InitializeFD(channel, c_bitrate.as_ptr()) })
+    } else {
+        let btr = classic_btr0_btr1(bitrate_cfg.nominal.bitrate)?;
+        Ok(unsafe { sys::CAN_Initialize(channel, btr, 0, 0, 0) })
+    }
+}
+
+/// Turn off everything that could introduce spurious frames in the receive
+/// stream. Some PCBUSB builds ignore these, so failures are only logged.
+fn configure_defaults(channel: sys::TPCANHandle) {
+    let off = sys::PCAN_PARAMETER_OFF.to_le_bytes();
+    for (name, param) in &[
+        ("STATUS", sys::PCAN_ALLOW_STATUS_FRAMES),
+        ("RTR", sys::PCAN_ALLOW_RTR_FRAMES),
+        ("ERROR", sys::PCAN_ALLOW_ERROR_FRAMES),
+        ("ECHO", sys::PCAN_ALLOW_ECHO_FRAMES),
+    ] {
+        let rc = unsafe {
+            sys::CAN_SetValue(
+                channel,
+                *param,
+                off.as_ptr() as *mut c_void,
+                off.len() as u32,
+            )
+        };
+        if rc != sys::PCAN_ERROR_OK {
+            debug!(
+                option = *name,
+                status = %PcanStatus::from_code(rc),
+                "PCAN: CAN_SetValue(OFF) rejected"
+            );
+        }
+    }
+}
+
+fn build_bitrate_string(nominal: &AdapterBitTiming, data: &AdapterBitTiming) -> String {
+    format!(
+        "f_clock_mhz={clock},nom_brp={nbrp},nom_tseg1={nt1},nom_tseg2={nt2},nom_sjw={nsjw},\
+         data_brp={dbrp},data_tseg1={dt1},data_tseg2={dt2},data_sjw={dsjw}",
+        clock = DEFAULT_FD_CLOCK_MHZ,
+        nbrp = nominal.brp,
+        nt1 = nominal.tseg1,
+        nt2 = nominal.tseg2,
+        nsjw = nominal.sjw,
+        dbrp = data.brp,
+        dt1 = data.tseg1,
+        dt2 = data.tseg2,
+        dsjw = data.sjw,
+    )
+}
+
+fn classic_btr0_btr1(bitrate_bps: u32) -> Result<u16> {
+    let btr = match bitrate_bps {
+        1_000_000 => sys::PCAN_BAUD_1M,
+        800_000 => sys::PCAN_BAUD_800K,
+        500_000 => sys::PCAN_BAUD_500K,
+        250_000 => sys::PCAN_BAUD_250K,
+        125_000 => sys::PCAN_BAUD_125K,
+        100_000 => sys::PCAN_BAUD_100K,
+        50_000 => sys::PCAN_BAUD_50K,
+        20_000 => sys::PCAN_BAUD_20K,
+        10_000 => sys::PCAN_BAUD_10K,
+        other => {
+            return Err(Error::UnsupportedBitrate(format!(
+                "{other} bps is not supported in classic CAN mode; \
+                 use one of 10k, 20k, 50k, 100k, 125k, 250k, 500k, 800k, 1M \
+                 or provide a CAN-FD data bitrate"
+            ))
+            .into())
+        }
+    };
+    Ok(btr)
+}
+
+fn build_msg(frame: &Frame) -> Result<sys::TPCANMsgFD> {
+    let mut msg = sys::TPCANMsgFD::zeroed();
+
+    let (id, extended) = match frame.id {
+        Identifier::Standard(id) => (id, false),
+        Identifier::Extended(id) => (id, true),
+    };
+    msg.id = id;
+
+    let dlc = DLC_TO_LEN
+        .iter()
+        .position(|&x| x == frame.data.len())
+        .ok_or(crate::Error::MalformedFrame)? as u8;
+    msg.dlc = dlc;
+
+    let mut flags = sys::PCAN_MESSAGE_STANDARD;
+    if extended {
+        flags |= sys::PCAN_MESSAGE_EXTENDED;
+    }
+    if frame.fd || frame.data.len() > 8 {
+        flags |= sys::PCAN_MESSAGE_FD | sys::PCAN_MESSAGE_BRS;
+    }
+    msg.msg_type = flags;
+
+    msg.data[..frame.data.len()].copy_from_slice(&frame.data);
+    Ok(msg)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::can::bitrate::BitrateBuilder;
+
+    #[test]
+    fn fd_bitrate_string_matches_acam220_profile() {
+        let cfg = BitrateBuilder::new::<Pcan>()
+            .bitrate(500_000)
+            .sample_point(0.8)
+            .sjw(1)
+            .data_bitrate(2_000_000)
+            .data_sample_point(0.8)
+            .data_sjw(1)
+            .build()
+            .unwrap();
+        let data = cfg.data.unwrap();
+        let bitrate_string = build_bitrate_string(&cfg.nominal, &data);
+        // 80 MHz / (brp=1) / (1 + 127 + 32) = 500_000 bps
+        assert!(bitrate_string.starts_with("f_clock_mhz=80,"));
+        assert!(bitrate_string.contains("nom_brp=1,nom_tseg1=127,nom_tseg2=32,nom_sjw=1,"));
+        assert!(bitrate_string.contains("data_brp=1,data_tseg1=31,data_tseg2=8,data_sjw=1"));
+    }
+
+    #[test]
+    fn classic_bitrate_maps_to_pcan_constant() {
+        assert_eq!(classic_btr0_btr1(500_000).unwrap(), sys::PCAN_BAUD_500K);
+        assert_eq!(classic_btr0_btr1(125_000).unwrap(), sys::PCAN_BAUD_125K);
+        assert!(matches!(
+            classic_btr0_btr1(333_333),
+            Err(crate::Error::PcanError(Error::UnsupportedBitrate(_)))
+        ));
+    }
+}

--- a/src/pcan/sys.rs
+++ b/src/pcan/sys.rs
@@ -1,0 +1,118 @@
+//! Raw FFI bindings for the PCBUSB / PCAN-Basic API.
+//!
+//! Only the subset needed by the PCAN [`CanAdapter`](crate::can::CanAdapter)
+//! implementation is declared. The wire format and constants are taken from
+//! PEAK-System's public `PCANBasic.h` / UV Software's `PCBUSB.h`.
+
+#![allow(non_snake_case, non_camel_case_types, dead_code)]
+
+use std::ffi::{c_char, c_void};
+
+pub(crate) type TPCANHandle = u16;
+pub(crate) type TPCANStatus = u32;
+
+// PCAN channel handles we iterate over for auto-discovery.
+pub(crate) const PCAN_USBBUS1: TPCANHandle = 0x51;
+pub(crate) const PCAN_USBBUS_LAST: TPCANHandle = 0x58;
+
+// PCAN-Basic status flags (subset).
+pub(crate) const PCAN_ERROR_OK: TPCANStatus = 0x00000;
+pub(crate) const PCAN_ERROR_QRCVEMPTY: TPCANStatus = 0x00020;
+pub(crate) const PCAN_ERROR_QXMTFULL: TPCANStatus = 0x00080;
+pub(crate) const PCAN_ERROR_BUSOFF: TPCANStatus = 0x00010;
+pub(crate) const PCAN_ERROR_BUSHEAVY: TPCANStatus = 0x00008;
+pub(crate) const PCAN_ERROR_BUSLIGHT: TPCANStatus = 0x00004;
+pub(crate) const PCAN_ERROR_BUSPASSIVE: TPCANStatus = 0x40000;
+
+// PCAN parameter IDs used by `CAN_SetValue`.
+pub(crate) const PCAN_ALLOW_STATUS_FRAMES: u8 = 0x1E;
+pub(crate) const PCAN_ALLOW_RTR_FRAMES: u8 = 0x1F;
+pub(crate) const PCAN_ALLOW_ERROR_FRAMES: u8 = 0x20;
+pub(crate) const PCAN_ALLOW_ECHO_FRAMES: u8 = 0x2C;
+
+pub(crate) const PCAN_PARAMETER_OFF: u32 = 0x00;
+pub(crate) const PCAN_PARAMETER_ON: u32 = 0x01;
+
+// PCAN message type bitmask values.
+pub(crate) const PCAN_MESSAGE_STANDARD: u8 = 0x00;
+pub(crate) const PCAN_MESSAGE_RTR: u8 = 0x01;
+pub(crate) const PCAN_MESSAGE_EXTENDED: u8 = 0x02;
+pub(crate) const PCAN_MESSAGE_FD: u8 = 0x04;
+pub(crate) const PCAN_MESSAGE_BRS: u8 = 0x08;
+pub(crate) const PCAN_MESSAGE_ECHO: u8 = 0x20;
+pub(crate) const PCAN_MESSAGE_ERRFRAME: u8 = 0x40;
+pub(crate) const PCAN_MESSAGE_STATUS: u8 = 0x80;
+
+// Classic CAN BTR0BTR1 constants (SJA1000 @ 16 MHz, as documented by PEAK).
+pub(crate) const PCAN_BAUD_1M: u16 = 0x0014;
+pub(crate) const PCAN_BAUD_800K: u16 = 0x0016;
+pub(crate) const PCAN_BAUD_500K: u16 = 0x001C;
+pub(crate) const PCAN_BAUD_250K: u16 = 0x011C;
+pub(crate) const PCAN_BAUD_125K: u16 = 0x031C;
+pub(crate) const PCAN_BAUD_100K: u16 = 0x432F;
+pub(crate) const PCAN_BAUD_50K: u16 = 0x472F;
+pub(crate) const PCAN_BAUD_20K: u16 = 0x532F;
+pub(crate) const PCAN_BAUD_10K: u16 = 0x672F;
+
+/// CAN-FD capable message layout.
+///
+/// Matches `tagTPCANMsgFD`: `DWORD` identifier, two `BYTE`s, then 64 `BYTE`s of
+/// payload. The C compiler pads the struct to a 4-byte boundary, which Rust's
+/// `repr(C)` reproduces.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub(crate) struct TPCANMsgFD {
+    pub id: u32,
+    pub msg_type: u8,
+    pub dlc: u8,
+    pub data: [u8; 64],
+}
+
+impl TPCANMsgFD {
+    pub(crate) fn zeroed() -> Self {
+        TPCANMsgFD {
+            id: 0,
+            msg_type: 0,
+            dlc: 0,
+            data: [0u8; 64],
+        }
+    }
+}
+
+#[link(name = "PCBUSB")]
+extern "C" {
+    pub(crate) fn CAN_Initialize(
+        channel: TPCANHandle,
+        btr0_btr1: u16,
+        hw_type: u8,
+        io_port: u32,
+        interrupt: u16,
+    ) -> TPCANStatus;
+
+    pub(crate) fn CAN_InitializeFD(channel: TPCANHandle, bitrate_fd: *const c_char) -> TPCANStatus;
+
+    pub(crate) fn CAN_Uninitialize(channel: TPCANHandle) -> TPCANStatus;
+
+    pub(crate) fn CAN_GetStatus(channel: TPCANHandle) -> TPCANStatus;
+
+    pub(crate) fn CAN_ReadFD(
+        channel: TPCANHandle,
+        msg: *mut TPCANMsgFD,
+        timestamp: *mut u64,
+    ) -> TPCANStatus;
+
+    pub(crate) fn CAN_WriteFD(channel: TPCANHandle, msg: *const TPCANMsgFD) -> TPCANStatus;
+
+    pub(crate) fn CAN_SetValue(
+        channel: TPCANHandle,
+        parameter: u8,
+        buffer: *mut c_void,
+        buffer_length: u32,
+    ) -> TPCANStatus;
+
+    pub(crate) fn CAN_GetErrorText(
+        error: TPCANStatus,
+        language: u16,
+        buffer: *mut c_char,
+    ) -> TPCANStatus;
+}

--- a/tests/adapter_tests.rs
+++ b/tests/adapter_tests.rs
@@ -41,6 +41,19 @@ fn vector_bitrate_config() -> automotive::can::bitrate::BitrateConfig {
         .unwrap()
 }
 
+#[cfg(all(target_os = "macos", feature = "test-pcan"))]
+fn pcan_bitrate_config() -> automotive::can::bitrate::BitrateConfig {
+    automotive::can::bitrate::BitrateBuilder::new::<automotive::pcan::Pcan>()
+        .bitrate(500_000)
+        .sample_point(0.8)
+        .sjw(1)
+        .data_bitrate(2_000_000)
+        .data_sample_point(0.8)
+        .data_sjw(1)
+        .build()
+        .unwrap()
+}
+
 fn get_test_frames(amount: usize) -> Vec<Frame> {
     let mut frames = vec![];
 
@@ -223,4 +236,20 @@ async fn socketcan_open_nonexistent() {
         Err(automotive::Error::NotFound) => {}
         _ => panic!("Expected NotFound error"),
     }
+}
+
+#[cfg(all(target_os = "macos", feature = "test-pcan"))]
+#[test]
+#[serial_test::serial]
+fn pcan_bulk_send_sync() {
+    let mut pcan = automotive::pcan::Pcan::new(0, pcan_bitrate_config()).unwrap();
+    bulk_send_sync(&mut pcan);
+}
+
+#[cfg(all(target_os = "macos", feature = "test-pcan"))]
+#[tokio::test]
+#[serial_test::serial]
+async fn pcan_bulk_send_async() {
+    let pcan = automotive::pcan::Pcan::new_async(0, pcan_bitrate_config()).unwrap();
+    bulk_send(&pcan).await;
 }


### PR DESCRIPTION
## Summary

Adds a new `CanAdapter` for PEAK's PCAN-USB and PCAN-USB FD devices on macOS, backed by UV Software's [PCBUSB](https://github.com/mac-can/PCBUSB-Library) library (the macOS port of PEAK's PCAN-Basic API). This is the native path for PEAK hardware on macOS, where SocketCAN isn't available.

The adapter plugs into the existing `BitrateBuilder` flow and follows the module layout used by `vector/` and `j2534/`.

## Implementation

- `src/pcan/` with:
  - `sys.rs` — minimal FFI (subset of PCAN-Basic: `CAN_Initialize[FD]`, `CAN_Read/WriteFD`, `CAN_Uninitialize`, `CAN_GetStatus`, `CAN_SetValue`, `CAN_GetErrorText`, and the `TPCANMsgFD` layout).
  - `error.rs` — `PcanStatus` wrapping raw codes with the English message from `CAN_GetErrorText`.
  - `mod.rs` — `Pcan` adapter, FD/classic init dispatch, and two unit tests.
- **Bitrate** is resolved through `BitrateBuilder::new::<Pcan>()`. A FD data phase triggers `CAN_InitializeFD` with a bitrate string built from the solved timing; a nominal-only config picks the matching BTR0BTR1 constant for classic CAN from PEAK's whitelist.
- **Loopback/ACK** is faked on successful `CAN_WriteFD`, matching the SocketCAN no-`IFF_ECHO` fallback — PCBUSB has no reliable hardware echo stream.
- **`get_adapter()`** iterates `PCAN_USBBUS1..8` on macOS when the `pcan` feature is enabled.
- **`build.rs`** links `libPCBUSB` and emits matching rpaths for Intel (`/usr/local/lib`) and Apple Silicon (`/opt/homebrew/lib`) prefixes. The rpaths apply to in-crate bins/tests; downstream consumers add their own rpath, mirroring the "distribute the DLL" model used by `vector-xl` and `j2534` on Windows.
- Docs updated in `src/lib.rs` (supported adapters + FAQ entry explaining the install path and the Linux → SocketCAN pointer).

## Feature flags

Opt-in, off by default, and macOS-only at build time:

- `pcan` — the adapter itself. Also added to `all-adapters`.
- `test-pcan` — gates the integration tests.

## Testing

Verified on a PCAN-USB FD (universal PCBUSB 0.12.1 dylib) against a live ECU at 500 kbit/s nominal / 2 Mbit/s data:

- `cargo build` with no features, `--all-features`, `--no-default-features --features pcan`, `--features default-adapters`: all clean.
- `cargo test --features pcan`: unit + doc tests pass (including 2 new unit tests: `fd_bitrate_string_matches_acam220_profile`, `classic_bitrate_maps_to_pcan_constant`).
- `cargo test --features test-pcan --test adapter_tests`: both `pcan_bulk_send_sync` (256 frames) and `pcan_bulk_send_async` (4096 frames) pass against live hardware — exercises TX/RX ordering, loopback emulation, and TX queue backpressure.
- `cargo clippy --features pcan`: no new warnings.
- `cargo fmt --check`: clean.
- End-to-end ISO-TP + UDS: `DiagnosticSessionControl(0x41)` + `ReadDataByIdentifier(0xF186)` round-trip with the expected payloads.

## Caveats

- Non-FD PCAN-USB hardware (IPEH-002021/002022) only supports the classic `CAN_Initialize` path. The adapter handles this correctly — a nominal-only `BitrateConfig` routes to `CAN_Initialize` — but I haven't tested on that specific device, only on PCAN-USB FD.
- PCBUSB installation is the consumer's responsibility (same model as `vxlapi64.dll` for Vector). The FAQ block in `src/lib.rs` links to the MacCAN project and notes the expected install path.