### PR TITLE
can: add optional CanAdapter::buffer_size flow control

### DIFF
--- a/src/can/async_can.rs
+++ b/src/can/async_can.rs
@@ -32,6 +32,12 @@ fn process<T: CanAdapter>(
     let mut buffer: VecDeque<Frame> = VecDeque::new();
     let mut callbacks: HashMap<BusIdentifier, VecDeque<FrameCallback>> = HashMap::new();
 
+    // Optional hardware flow-control limit. When set, we keep the number of
+    // frames in flight (sent but not yet acknowledged via loopback) plus those
+    // queued to send below this limit so the adapter's buffer is not overrun.
+    let buffer_size = adapter.buffer_size();
+    let mut in_flight: usize = 0;
+
     while shutdown_receiver.try_recv().is_err() {
         let frames: Vec<Frame> = match adapter.recv() {
             Ok(f) => f,
@@ -48,6 +54,8 @@ fn process<T: CanAdapter>(
 
             // Wake up sender
             if frame.loopback {
+                in_flight = in_flight.saturating_sub(1);
+
                 let callback = callbacks
                     .entry((frame.bus, frame.id))
                     .or_default()
@@ -69,25 +77,40 @@ fn process<T: CanAdapter>(
             rx_sender.send(frame).unwrap();
         }
 
+        // Move queued TX frames into the send buffer, respecting the optional
+        // hardware buffer limit.
         // TODO: use poll_recv_many?
-        while let Ok((frame, callback)) = tx_receiver.try_recv() {
-            let mut loopback_frame = frame.clone();
-            loopback_frame.loopback = true;
-
-            // Insert callback into hashmap
-            callbacks
-                .entry((frame.bus, frame.id))
-                .or_default()
-                .push_back((loopback_frame, callback));
-
-            if DEBUG {
-                debug! {"TX {:?}", frame};
+        loop {
+            if let Some(max) = buffer_size {
+                if in_flight + buffer.len() >= max {
+                    break;
+                }
             }
 
-            buffer.push_back(frame);
+            match tx_receiver.try_recv() {
+                Ok((frame, callback)) => {
+                    let mut loopback_frame = frame.clone();
+                    loopback_frame.loopback = true;
+
+                    // Insert callback into hashmap
+                    callbacks
+                        .entry((frame.bus, frame.id))
+                        .or_default()
+                        .push_back((loopback_frame, callback));
+
+                    if DEBUG {
+                        debug! {"TX {:?}", frame};
+                    }
+
+                    buffer.push_back(frame);
+                }
+                Err(_) => break,
+            }
         }
         if !buffer.is_empty() {
+            let queued = buffer.len();
             adapter.send(&mut buffer).unwrap();
+            in_flight += queued - buffer.len();
 
             if !buffer.is_empty() {
                 debug!(

--- a/src/can/mod.rs
+++ b/src/can/mod.rs
@@ -129,6 +129,16 @@ pub trait CanAdapter {
     fn send(&mut self, frames: &mut VecDeque<crate::can::Frame>) -> crate::Result<()>;
     fn recv(&mut self) -> crate::Result<Vec<Frame>>;
 
+    /// Maximum number of frames the adapter can have in flight at once, i.e.
+    /// transmitted but not yet acknowledged back via a loopback frame.
+    ///
+    /// Adapters backed by hardware with a finite buffer should return `Some(n)`
+    /// so the [`crate::can::AsyncCanAdapter`] throttles transmission and does not
+    /// overrun the buffer. The default of `None` means no limit is enforced.
+    fn buffer_size(&self) -> Option<usize> {
+        None
+    }
+
     /// Adapter timing constants for bitrate configuration helpers.
     ///
     /// Adapters that support [`crate::can::bitrate::BitrateBuilder`] should override this.

--- a/tests/adapter_tests.rs
+++ b/tests/adapter_tests.rs
@@ -81,6 +81,11 @@ fn get_test_frames(amount: usize) -> Vec<Frame> {
 fn bulk_send_sync<T: CanAdapter>(adapter: &mut T) {
     let frames = get_test_frames(BULK_NUM_FRAMES_SYNC);
 
+    // The blocking sync test transmits everything before reading any echoes
+    // back, so cap the number of frames to what the adapter can buffer at once.
+    let limit = adapter.buffer_size().unwrap_or(frames.len());
+    let frames: Vec<Frame> = frames.into_iter().take(limit).collect();
+
     let mut to_send: VecDeque<Frame> = frames.clone().into();
     while !to_send.is_empty() {
         adapter.send(&mut to_send).unwrap();


### PR DESCRIPTION
Adapters backed by hardware with a finite TX/RX buffer can now report the maximum number of frames that may be in flight (transmitted but not yet acknowledged via loopback) through CanAdapter::buffer_size(). AsyncCanAdapter uses this to throttle transmission so the buffer is not overrun, and the blocking bulk_send_sync test caps its frame count to it.

Defaults to None (no limit), so existing adapters are unaffected.