### PR TITLE
peak: add raw-USB driver for PCAN-USB FD family

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,18 +13,20 @@ repository = "https://github.com/I-CAN-hack/automotive"
 default = []
 all = ["all-adapters", "serde"]
 default-adapters = ["panda", "socketcan"]
-all-adapters = ["default-adapters", "vector-xl", "j2534"]
+all-adapters = ["default-adapters", "vector-xl", "j2534", "peak"]
 serde = ["dep:serde"]
 
 # adapters
 vector-xl = ["dep:bindgen", "dep:libloading"]
 j2534 = ["dep:libloading", "dep:winreg"]
 panda = ["dep:rusb"]
+peak = ["dep:rusb"]
 socketcan = ["dep:libc", "dep:socket2"]
 
 # adapter tests
 test-j2534 = ["j2534"]
 test-panda = ["panda"]
+test-peak = ["peak"]
 test-socketcan = ["socketcan"]
 test-vcan = ["socketcan"]
 test-vector = ["vector-xl"]

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The following CAN adapters are supported.
 ### Supported CAN adapters
  - SocketCAN (Linux only, enable with the `socketcan` feature)
  - comma.ai panda (all platforms using [rusb](https://crates.io/crates/rusb), enable with the `panda` feature)
+ - PEAK PCAN-USB FD family (all platforms using [rusb](https://crates.io/crates/rusb), enable with the `peak` feature)
  - J2534 PassThru Devices (Windows only, enable with the `j2534` feature)
  - Vector Devices (Windows x64 only, enable with the `vector-xl` feature)
 
@@ -65,6 +66,14 @@ This library supports awaiting a sent frame and waiting for the ACK on the CAN b
    - neoVI/ValueCAN: Use of Intrepid Control System's devices is not recommended due to issues in their SocketCAN driver. If many frames are transmitted simultaneously it will cause the whole system/kernel to hang. [intrepid-socketcan-kernel-module#20](https://github.com/intrepidcs/intrepid-socketcan-kernel-module/issues/20) tracks this issue.
  - comma.ai panda
    - The panda does not retry frames that are not ACKed, and drops them instead. This can cause panics in some internal parts of the library when frames are dropped. [panda#1922](https://github.com/commaai/panda/issues/1922) tracks this issue.
+ - PEAK PCAN-USB FD (raw USB, `peak` feature)
+   - This driver talks to the device directly over USB instead of through SocketCAN, so it does not need the `peak_usb` kernel module to be unloaded; the in-kernel driver is detached automatically when the device is opened.
+   - On Linux the USB device node is owned by root by default. To use the adapter without running as root, install a udev rule granting access to your user, e.g. in `/etc/udev/rules.d/70-pcan-usb-fd.rules`:
+     ```
+     # PEAK System PCAN-USB FD family
+     SUBSYSTEM=="usb", ATTRS{idVendor}=="0c72", MODE="0666"
+     ```
+     Then reload the rules and replug the device: `sudo udevadm control --reload-rules && sudo udevadm trigger`.
  - J2534 PassThru Devices are supported through the `j2534` feature. The library provides `J2534CanAdapter` for raw CAN access, and `J2534NativeIsoTpTransport` to offload ISO-TP framing, flow-control, and timing to the adapter. It is recommended to use `J2534CanAdapter` unless you have specific speed or latency requirements.
  - Vector Devices are supported through the Vector XL Driver Library, and support can be enabled using the `vector-xl` feature. Make sure to distribute `vxlapi64.dll` alongside your application.
 

--- a/src/can/adapter.rs
+++ b/src/can/adapter.rs
@@ -20,6 +20,21 @@ pub fn get_adapter() -> Result<crate::can::AsyncCanAdapter, crate::error::Error>
         }
     }
 
+    #[cfg(feature = "peak")]
+    {
+        let bitrate_cfg = crate::can::bitrate::BitrateBuilder::new::<crate::peak::Peak>()
+            .bitrate(500_000)
+            .sample_point(0.8)
+            .data_bitrate(2_000_000)
+            .data_sample_point(0.8)
+            .build()
+            .unwrap();
+
+        if let Ok(peak) = crate::peak::Peak::new_async(bitrate_cfg) {
+            return Ok(peak);
+        }
+    }
+
     #[cfg(all(target_os = "linux", feature = "socketcan"))]
     {
         // TODO: iterate over all available SocketCAN adapters to also find things like vcan0

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,7 +21,7 @@ pub enum Error {
     #[error(transparent)]
     IsoTPError(#[from] crate::isotp::Error),
 
-    #[cfg(feature = "panda")]
+    #[cfg(any(feature = "panda", feature = "peak"))]
     #[error(transparent)]
     LibUsbError(#[from] rusb::Error),
     #[error(transparent)]
@@ -42,6 +42,10 @@ pub enum Error {
     #[cfg(feature = "panda")]
     #[error(transparent)]
     PandaError(#[from] crate::panda::Error),
+
+    #[cfg(feature = "peak")]
+    #[error(transparent)]
+    PeakError(#[from] crate::peak::Error),
 }
 
 impl From<tokio_stream::Elapsed> for Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,3 +105,7 @@ pub mod j2534;
 #[cfg(feature = "panda")]
 #[cfg_attr(docsrs, doc(cfg(feature = "panda")))]
 pub mod panda;
+
+#[cfg(feature = "peak")]
+#[cfg_attr(docsrs, doc(cfg(feature = "peak")))]
+pub mod peak;

--- a/src/peak/constants.rs
+++ b/src/peak/constants.rs
@@ -1,0 +1,121 @@
+//! Protocol constants for the PEAK PCAN-USB FD family adapters.
+//!
+//! These adapters speak the "uCAN" message/command protocol over raw USB bulk
+//! endpoints. The values below describe that wire format. Some constants are
+//! kept for completeness as protocol documentation even if currently unused.
+#![allow(dead_code)]
+
+/// PEAK System USB vendor ID.
+pub const USB_VID: u16 = 0x0c72;
+
+/// Product IDs of the PCAN-USB FD family. All of these speak the uCAN protocol
+/// implemented by this module. The classic PCAN-USB / PCAN-USB Pro (non-FD) use
+/// a different, older protocol and are intentionally not supported here.
+pub const PID_PCAN_USB_PRO_FD: u16 = 0x0011;
+pub const PID_PCAN_USB_FD: u16 = 0x0012;
+pub const PID_PCAN_USB_CHIP: u16 = 0x0013;
+pub const PID_PCAN_USB_X6: u16 = 0x0014;
+
+/// All supported product IDs.
+pub const SUPPORTED_PIDS: &[u16] = &[
+    PID_PCAN_USB_PRO_FD,
+    PID_PCAN_USB_FD,
+    PID_PCAN_USB_CHIP,
+    PID_PCAN_USB_X6,
+];
+
+/// CAN controller input clock in Hz.
+pub const CLOCK_HZ: u32 = 80_000_000;
+
+/// Default USB endpoints, used unless the firmware advertises its own.
+/// Command endpoints carry the uCAN command list, message endpoints carry frames.
+pub const DEFAULT_EP_CMD_OUT: u8 = 0x01;
+pub const DEFAULT_EP_CMD_IN: u8 = 0x81;
+pub const DEFAULT_EP_MSG_OUT: u8 = 0x02;
+pub const DEFAULT_EP_MSG_IN: u8 = 0x82;
+
+/// USB control transfer: vendor request, recipient "other".
+/// Combined with the IN/OUT direction bit by the control helpers.
+pub const CTRL_REQ_INFO: u8 = 0;
+pub const CTRL_REQ_FCT: u8 = 2;
+
+/// `wValue` for the firmware-info request.
+pub const INFO_FW: u16 = 1;
+
+/// `wValue` and payload length to tell the device the driver is (un)loaded.
+pub const FCT_DRV_LOADED: u16 = 5;
+pub const FCT_DRV_LOADED_LEN: usize = 16;
+
+/// Length of the firmware-info structure returned by [`CTRL_REQ_INFO`]/[`INFO_FW`].
+pub const FW_INFO_LEN: usize = 36;
+/// Offsets into the firmware-info structure.
+pub const FW_INFO_TYPE_OFFSET: usize = 2;
+pub const FW_INFO_FW_VERSION_OFFSET: usize = 9;
+pub const FW_INFO_CMD_OUT_EP_OFFSET: usize = 28;
+pub const FW_INFO_CMD_IN_EP_OFFSET: usize = 29;
+pub const FW_INFO_DATA_OUT_EP_OFFSET: usize = 30;
+pub const FW_INFO_DATA_IN_EP_OFFSET: usize = 32;
+/// Firmware-info `type` value at/above which endpoint numbers are embedded.
+pub const FW_INFO_TYPE_EXT: u16 = 2;
+
+/// uCAN command opcodes (low 10 bits of the `opcode_channel` field).
+pub const CMD_RESET_MODE: u16 = 0x001;
+pub const CMD_NORMAL_MODE: u16 = 0x002;
+pub const CMD_LISTEN_ONLY_MODE: u16 = 0x003;
+pub const CMD_TIMING_SLOW: u16 = 0x004;
+pub const CMD_TIMING_FAST: u16 = 0x005;
+pub const CMD_FILTER_STD: u16 = 0x008;
+pub const CMD_WR_ERR_CNT: u16 = 0x00a;
+pub const CMD_SET_EN_OPTION: u16 = 0x00b;
+pub const CMD_CLR_DIS_OPTION: u16 = 0x00c;
+pub const CMD_END_OF_COLLECTION: u16 = 0x3ff;
+
+/// Extended (vendor-specific, non-uCAN) commands.
+pub const CMD_CLOCK_SET: u16 = 0x80;
+pub const CMD_LED_SET: u16 = 0x86;
+
+/// Clock mode selecting the 80 MHz domain.
+pub const CLOCK_80MHZ: u8 = 0x00;
+
+/// Default error-warning limit used in the slow bit-timing command.
+pub const DEFAULT_ERROR_WARNING_LIMIT: u8 = 96;
+
+/// `WR_ERR_CNT` select-mask bits (enable writing the Tx / Rx counters).
+pub const WRERRCNT_TX_ENABLE: u16 = 0x4000;
+pub const WRERRCNT_RX_ENABLE: u16 = 0x8000;
+
+/// Option bit selecting ISO CAN-FD framing.
+pub const OPTION_CAN_FD_ISO: u16 = 0x0004;
+
+/// uCAN message types (the `type` field of a record).
+pub const MSG_CAN_RX: u16 = 0x0001;
+pub const MSG_ERROR: u16 = 0x0002;
+pub const MSG_STATUS: u16 = 0x0003;
+pub const MSG_CALIBRATION: u16 = 0x0100;
+pub const MSG_OVERRUN: u16 = 0x0101;
+pub const MSG_CAN_TX: u16 = 0x1000;
+
+/// uCAN CAN-message flag bits (the 16-bit `flags` field).
+pub const FLAG_SELF_RECEIVE: u16 = 0x80;
+pub const FLAG_ERROR_STATE_IND: u16 = 0x40;
+pub const FLAG_BITRATE_SWITCH: u16 = 0x20;
+pub const FLAG_EXT_DATA_LEN: u16 = 0x10;
+pub const FLAG_SINGLE_SHOT: u16 = 0x08;
+pub const FLAG_LOOPED_BACK: u16 = 0x04;
+pub const FLAG_EXT_ID: u16 = 0x02;
+pub const FLAG_RTR: u16 = 0x01;
+
+/// Header size (bytes) of a transmitted CAN message record.
+pub const TX_MSG_HEADER_SIZE: usize = 20;
+/// Header size (bytes) of a received CAN message record.
+pub const RX_MSG_HEADER_SIZE: usize = 28;
+/// Size (bytes) of a single command record. All commands share this size.
+pub const COMMAND_SIZE: usize = 8;
+
+/// Size of the device command buffer. A single USB transfer of commands must
+/// not exceed this.
+pub const CMD_BUFFER_SIZE: usize = 512;
+/// Size of a single USB transfer of transmitted CAN messages.
+pub const TX_BUFFER_SIZE: usize = 512;
+/// Size of the buffer used to read received CAN messages.
+pub const RX_BUFFER_SIZE: usize = 2048;

--- a/src/peak/error.rs
+++ b/src/peak/error.rs
@@ -1,0 +1,18 @@
+//! Error types for the PEAK PCAN-USB FD adapter.
+use thiserror::Error;
+
+#[derive(Error, Debug, PartialEq, Clone)]
+pub enum Error {
+    /// A frame had a payload length that is not a valid CAN(-FD) length.
+    #[error("Malformed Frame")]
+    MalformedFrame,
+    /// The firmware-info response was shorter than expected.
+    #[error("Short firmware info response")]
+    ShortFirmwareInfo,
+    /// A CAN-FD data bitrate was requested but none was configured.
+    #[error("Missing CAN-FD data bitrate configuration")]
+    MissingDataBitrate,
+    /// A USB command transfer was only partially written to the device.
+    #[error("Incomplete command write: {written} of {expected} bytes")]
+    IncompleteWrite { written: usize, expected: usize },
+}

--- a/src/peak/mod.rs
+++ b/src/peak/mod.rs
@@ -1,0 +1,379 @@
+//! Raw-USB driver for the PEAK PCAN-USB FD family of CAN adapters.
+//!
+//! This talks the "uCAN" protocol directly over USB bulk endpoints using
+//! [rusb](https://crates.io/crates/rusb), without relying on the in-kernel
+//! `peak_usb` driver or SocketCAN. The in-kernel driver is detached
+//! automatically when the device is opened.
+//!
+//! On Linux, accessing the USB device as a non-root user requires a udev rule
+//! granting access (see the crate README).
+//!
+//! Both classic CAN and CAN-FD are supported, including full control over the
+//! nominal and data-phase bit timing via [`crate::can::bitrate::BitrateBuilder`].
+
+mod constants;
+pub mod error;
+mod protocol;
+
+pub use error::Error;
+
+use std::collections::VecDeque;
+use std::time::Duration;
+
+use crate::can::bitrate::{AdapterTimingConst, BitTimingConst, BitrateConfig};
+use crate::can::{AsyncCanAdapter, CanAdapter, Frame};
+use crate::peak::constants::*;
+use crate::Result;
+use tracing::{info, warn};
+
+const CMD_TIMEOUT: Duration = Duration::from_millis(1000);
+const TX_TIMEOUT: Duration = Duration::from_millis(1000);
+const RX_TIMEOUT: Duration = Duration::from_millis(5);
+const FLUSH_TIMEOUT: Duration = Duration::from_millis(10);
+
+/// Maximum number of command records per USB transfer, leaving room for the
+/// trailing end-of-collection marker.
+const MAX_CMDS_PER_TRANSFER: usize = CMD_BUFFER_SIZE / COMMAND_SIZE - 1;
+
+/// Number of frames the device can reliably hold in flight (transmitted but not
+/// yet read back) before its internal FIFO overruns. The [`AsyncCanAdapter`]
+/// uses this (via [`CanAdapter::buffer_size`]) to throttle transmission. Chosen
+/// conservatively below the observed hardware capacity.
+const PEAK_BUFFER_SIZE: usize = 128;
+
+/// The PCAN-USB FD family uses a fixed 80 MHz controller clock.
+const PEAK_NOMINAL_TIMING: BitTimingConst = BitTimingConst {
+    clock_hz: CLOCK_HZ,
+    tseg1_min: 1,
+    tseg1_max: 1 << 8,
+    tseg2_min: 1,
+    tseg2_max: 1 << 7,
+    sjw_max: 1 << 7,
+    brp_min: 1,
+    brp_max: 1 << 10,
+    brp_inc: 1,
+};
+
+const PEAK_DATA_TIMING: BitTimingConst = BitTimingConst {
+    clock_hz: CLOCK_HZ,
+    tseg1_min: 1,
+    tseg1_max: 1 << 5,
+    tseg2_min: 1,
+    tseg2_max: 1 << 4,
+    sjw_max: 1 << 4,
+    brp_min: 1,
+    brp_max: 1 << 10,
+    brp_inc: 1,
+};
+
+const PEAK_TIMING_CONST: AdapterTimingConst = AdapterTimingConst {
+    nominal: PEAK_NOMINAL_TIMING,
+    data: Some(PEAK_DATA_TIMING),
+};
+
+/// Blocking implementation of the PEAK PCAN-USB FD adapter.
+pub struct Peak {
+    handle: rusb::DeviceHandle<rusb::GlobalContext>,
+    /// CAN channel index (0 for single-channel devices like the PCAN-USB FD).
+    channel: u8,
+    /// USB endpoints in use (resolved from firmware info or defaults).
+    ep_cmd_out: u8,
+    ep_msg_out: u8,
+    ep_msg_in: u8,
+    /// Whether CAN-FD frames should request a bitrate switch (data bitrate set).
+    use_brs: bool,
+    /// Whether the firmware supports toggling ISO / non-ISO CAN-FD framing.
+    iso_fd_supported: bool,
+}
+
+// rusb's GlobalContext handle is safe to move between threads.
+unsafe impl Send for Peak {}
+
+impl Peak {
+    /// Connect to the first available PCAN-USB FD family adapter and wrap it in
+    /// an [`AsyncCanAdapter`].
+    pub fn new_async(bitrate_cfg: BitrateConfig) -> Result<AsyncCanAdapter> {
+        let peak = Peak::new(bitrate_cfg)?;
+        Ok(AsyncCanAdapter::new(peak))
+    }
+
+    /// Connect to the first available PCAN-USB FD family adapter.
+    ///
+    /// The in-kernel `peak_usb` driver, if bound, is detached automatically.
+    pub fn new(bitrate_cfg: BitrateConfig) -> Result<Peak> {
+        for device in rusb::devices()?.iter() {
+            let desc = match device.device_descriptor() {
+                Ok(desc) => desc,
+                Err(_) => continue,
+            };
+
+            if desc.vendor_id() != USB_VID || !SUPPORTED_PIDS.contains(&desc.product_id()) {
+                continue;
+            }
+
+            let handle = device.open()?;
+
+            // Detach the in-kernel peak_usb driver if it is still bound, so we
+            // can claim the interface for raw USB access.
+            handle.set_auto_detach_kernel_driver(true).ok();
+            handle.claim_interface(0)?;
+
+            // Read firmware info to learn the firmware version and (on newer
+            // firmware) which endpoints to use.
+            let (fw_info, fw_len) = read_fw_info(&handle)?;
+            let fw_type = u16::from_le_bytes([
+                fw_info[FW_INFO_TYPE_OFFSET],
+                fw_info[FW_INFO_TYPE_OFFSET + 1],
+            ]);
+            let fw_major = fw_info[FW_INFO_FW_VERSION_OFFSET];
+            let iso_fd_supported = fw_major >= 2;
+
+            let (ep_cmd_out, ep_msg_out, ep_msg_in) =
+                if fw_type >= FW_INFO_TYPE_EXT && fw_len >= FW_INFO_LEN {
+                    (
+                        fw_info[FW_INFO_CMD_OUT_EP_OFFSET] & 0x7f,
+                        fw_info[FW_INFO_DATA_OUT_EP_OFFSET] & 0x7f,
+                        fw_info[FW_INFO_DATA_IN_EP_OFFSET] | 0x80,
+                    )
+                } else {
+                    (DEFAULT_EP_CMD_OUT, DEFAULT_EP_MSG_OUT, DEFAULT_EP_MSG_IN)
+                };
+
+            let peak = Peak {
+                handle,
+                channel: 0,
+                ep_cmd_out,
+                ep_msg_out,
+                ep_msg_in,
+                use_brs: bitrate_cfg.data.is_some(),
+                iso_fd_supported,
+            };
+
+            // Tell the device a host driver is now in control.
+            peak.set_driver_loaded(true)?;
+
+            // Apply clock, bit timing, filters and go bus-on.
+            peak.configure(&bitrate_cfg)?;
+
+            // Drop anything buffered from before we took over.
+            peak.flush_rx()?;
+
+            info!(
+                "Connected to PEAK PCAN-USB FD (fw v{}.{}.{}, channel {})",
+                fw_info[FW_INFO_FW_VERSION_OFFSET],
+                fw_info[FW_INFO_FW_VERSION_OFFSET + 1],
+                fw_info[FW_INFO_FW_VERSION_OFFSET + 2],
+                peak.channel,
+            );
+
+            return Ok(peak);
+        }
+
+        Err(crate::Error::NotFound)
+    }
+
+    /// Send a list of command records, terminated with an end-of-collection
+    /// marker, split across USB transfers no larger than the command buffer.
+    fn send_commands(&self, commands: &[protocol::Command]) -> Result<()> {
+        for chunk in commands.chunks(MAX_CMDS_PER_TRANSFER) {
+            let mut buf = Vec::with_capacity((chunk.len() + 1) * COMMAND_SIZE);
+            for cmd in chunk {
+                buf.extend_from_slice(cmd);
+            }
+            buf.extend_from_slice(&protocol::end_of_collection());
+
+            // A command list must be delivered as one complete transfer; a short
+            // write would leave the device with a torn command record. Fail loudly
+            // rather than silently misconfigure it.
+            let written = self.handle.write_bulk(self.ep_cmd_out, &buf, CMD_TIMEOUT)?;
+            if written != buf.len() {
+                return Err(Error::IncompleteWrite {
+                    written,
+                    expected: buf.len(),
+                }
+                .into());
+            }
+        }
+        Ok(())
+    }
+
+    /// Tell the device whether a host driver is loaded (vendor control request).
+    fn set_driver_loaded(&self, loaded: bool) -> Result<()> {
+        let mut buf = [0u8; FCT_DRV_LOADED_LEN];
+        buf[1] = loaded as u8;
+
+        let request_type = rusb::request_type(
+            rusb::Direction::Out,
+            rusb::RequestType::Vendor,
+            rusb::Recipient::Other,
+        );
+        self.handle.write_control(
+            request_type,
+            CTRL_REQ_FCT,
+            FCT_DRV_LOADED,
+            0,
+            &buf,
+            CMD_TIMEOUT,
+        )?;
+        Ok(())
+    }
+
+    /// Configure clock, bit timing and filters, then bring the bus up.
+    fn configure(&self, cfg: &BitrateConfig) -> Result<()> {
+        let ch = self.channel;
+
+        // Select the 80 MHz clock domain.
+        self.send_commands(&[protocol::cmd_set_clock(ch, CLOCK_80MHZ)])?;
+
+        // Bit timing can only be set while in reset (bus-off) mode.
+        self.send_commands(&[protocol::cmd_reset_mode(ch)])?;
+        self.send_commands(&[protocol::cmd_timing_slow(ch, &cfg.nominal)])?;
+        if let Some(data) = &cfg.data {
+            self.send_commands(&[protocol::cmd_timing_fast(ch, data)])?;
+        }
+
+        // Accept every standard ID. Extended IDs are not affected by this filter.
+        self.send_commands(&protocol::cmd_filter_accept_all(ch))?;
+
+        // Bring the bus up: clear error counters, select ISO CAN-FD framing if
+        // the firmware supports it, then enter normal mode.
+        let mut bus_on = vec![protocol::cmd_reset_error_counters(ch)];
+        if self.iso_fd_supported {
+            bus_on.push(protocol::cmd_set_fd_iso(ch, true));
+        }
+        bus_on.push(protocol::cmd_normal_mode(ch));
+        self.send_commands(&bus_on)?;
+
+        Ok(())
+    }
+
+    fn set_bus_off(&self) -> Result<()> {
+        self.send_commands(&[protocol::cmd_reset_mode(self.channel)])
+    }
+
+    /// Drain any frames the device has already buffered.
+    fn flush_rx(&self) -> Result<()> {
+        let mut buf = [0u8; RX_BUFFER_SIZE];
+        loop {
+            match self
+                .handle
+                .read_bulk(self.ep_msg_in, &mut buf, FLUSH_TIMEOUT)
+            {
+                Ok(0) => return Ok(()),
+                Ok(_) => continue,
+                Err(rusb::Error::Timeout) => return Ok(()),
+                Err(e) => return Err(e.into()),
+            }
+        }
+    }
+}
+
+impl CanAdapter for Peak {
+    fn send(&mut self, frames: &mut VecDeque<Frame>) -> Result<()> {
+        while !frames.is_empty() {
+            // Pack as many frames as fit into a single USB transfer, remembering
+            // the buffer offset at which each frame's record ends.
+            let mut buf = Vec::with_capacity(TX_BUFFER_SIZE);
+            let mut record_ends: Vec<usize> = Vec::new();
+
+            for frame in frames.iter() {
+                let record = protocol::encode_tx_frame(frame, self.use_brs)?;
+                // Always keep room for the 4-byte zero terminator record.
+                if !record_ends.is_empty() && buf.len() + record.len() + 4 > TX_BUFFER_SIZE {
+                    break;
+                }
+                buf.extend_from_slice(&record);
+                record_ends.push(buf.len());
+            }
+            buf.extend_from_slice(&[0u8; 4]); // zero-size record: end of list
+
+            match self.handle.write_bulk(self.ep_msg_out, &buf, TX_TIMEOUT) {
+                Ok(written) => {
+                    // Only frames whose record was fully transmitted are sent;
+                    // a short write leaves the rest queued to retry. The device
+                    // parses records up to the transfer length and drops any torn
+                    // trailing record, so a re-sent frame arrives intact.
+                    let sent = record_ends
+                        .iter()
+                        .take_while(|&&end| end <= written)
+                        .count();
+                    for _ in 0..sent {
+                        frames.pop_front();
+                    }
+                    if sent < record_ends.len() {
+                        // Short write: leave the remaining frames queued.
+                        break;
+                    }
+                }
+                // No space right now: leave frames queued and retry next call.
+                Err(rusb::Error::Timeout) => break,
+                Err(rusb::Error::NoDevice) => return Err(crate::Error::Disconnected),
+                Err(e) => return Err(e.into()),
+            }
+        }
+        Ok(())
+    }
+
+    fn recv(&mut self) -> Result<Vec<Frame>> {
+        let mut buf = [0u8; RX_BUFFER_SIZE];
+
+        let n = match self.handle.read_bulk(self.ep_msg_in, &mut buf, RX_TIMEOUT) {
+            Ok(n) => n,
+            Err(rusb::Error::Timeout) => return Ok(vec![]),
+            Err(rusb::Error::NoDevice) => return Err(crate::Error::Disconnected),
+            Err(e) => return Err(e.into()),
+        };
+
+        let (frames, overruns) = protocol::parse_rx_buffer(&buf[..n]);
+        if overruns > 0 {
+            warn!(
+                "PEAK reported {} RX overrun message(s); frames may be lost",
+                overruns
+            );
+        }
+        Ok(frames)
+    }
+
+    /// The device has a finite TX/RX FIFO, so cap the number of frames in flight.
+    fn buffer_size(&self) -> Option<usize> {
+        Some(PEAK_BUFFER_SIZE)
+    }
+
+    fn timing_const() -> AdapterTimingConst
+    where
+        Self: Sized,
+    {
+        PEAK_TIMING_CONST
+    }
+}
+
+impl Drop for Peak {
+    fn drop(&mut self) {
+        // Best-effort: take the bus down and tell the device the driver is gone.
+        let _ = self.set_bus_off();
+        let _ = self.set_driver_loaded(false);
+    }
+}
+
+/// Read the firmware-info structure via a vendor control request.
+///
+/// Returns the buffer and the number of bytes actually read.
+fn read_fw_info(
+    handle: &rusb::DeviceHandle<rusb::GlobalContext>,
+) -> Result<([u8; FW_INFO_LEN], usize)> {
+    let mut buf = [0u8; FW_INFO_LEN];
+    let request_type = rusb::request_type(
+        rusb::Direction::In,
+        rusb::RequestType::Vendor,
+        rusb::Recipient::Other,
+    );
+    let n = handle.read_control(
+        request_type,
+        CTRL_REQ_INFO,
+        INFO_FW,
+        0,
+        &mut buf,
+        CMD_TIMEOUT,
+    )?;
+    Ok((buf, n))
+}

--- a/src/peak/protocol.rs
+++ b/src/peak/protocol.rs
@@ -1,0 +1,451 @@
+//! Encoding and decoding of the uCAN wire format used by the PCAN-USB FD family.
+//!
+//! The device exchanges fixed 8-byte *command* records on the command endpoint
+//! and variable length *message* records (CAN frames, status, ...) on the
+//! message endpoints. Both are little-endian.
+
+use crate::can::bitrate::AdapterBitTiming;
+use crate::can::{Frame, Identifier, DLC_TO_LEN};
+use crate::peak::constants::*;
+use crate::peak::error::Error;
+
+/// Round `n` up to the next multiple of 4.
+fn align4(n: usize) -> usize {
+    (n + 3) & !3
+}
+
+/// Build the 16-bit `opcode_channel` field shared by every command/message.
+fn opcode_channel(channel: u8, opcode: u16) -> u16 {
+    ((channel as u16) << 12) | (opcode & 0x3ff)
+}
+
+/// Look up the DLC (data length code) for a given payload length.
+fn len_to_dlc(len: usize) -> Result<u8, Error> {
+    DLC_TO_LEN
+        .iter()
+        .position(|&l| l == len)
+        .map(|dlc| dlc as u8)
+        .ok_or(Error::MalformedFrame)
+}
+
+/// Convert a DLC back to a payload length, honoring the CAN-FD lookup table for
+/// FD frames and clamping classic frames to 8 bytes.
+fn dlc_to_len(dlc: u8, fd: bool) -> usize {
+    let dlc = (dlc & 0xf) as usize;
+    if fd {
+        DLC_TO_LEN[dlc]
+    } else {
+        DLC_TO_LEN[dlc].min(8)
+    }
+}
+
+/// A single 8-byte command record.
+pub type Command = [u8; COMMAND_SIZE];
+
+fn command(channel: u8, opcode: u16) -> Command {
+    let mut cmd = [0u8; COMMAND_SIZE];
+    cmd[0..2].copy_from_slice(&opcode_channel(channel, opcode).to_le_bytes());
+    cmd
+}
+
+/// The "end of collection" marker terminating a command list.
+pub fn end_of_collection() -> Command {
+    [0xff; COMMAND_SIZE]
+}
+
+/// Set the CAN controller clock domain (e.g. [`CLOCK_80MHZ`]).
+pub fn cmd_set_clock(channel: u8, clock_mode: u8) -> Command {
+    let mut cmd = command(channel, CMD_CLOCK_SET);
+    cmd[2] = clock_mode;
+    cmd
+}
+
+/// Enter reset mode (bus off). Bit timing can only be changed while in reset.
+pub fn cmd_reset_mode(channel: u8) -> Command {
+    command(channel, CMD_RESET_MODE)
+}
+
+/// Enter operational mode (bus on).
+pub fn cmd_normal_mode(channel: u8) -> Command {
+    command(channel, CMD_NORMAL_MODE)
+}
+
+/// Reset both error counters to zero.
+pub fn cmd_reset_error_counters(channel: u8) -> Command {
+    let mut cmd = command(channel, CMD_WR_ERR_CNT);
+    let sel_mask = WRERRCNT_TX_ENABLE | WRERRCNT_RX_ENABLE;
+    cmd[2..4].copy_from_slice(&sel_mask.to_le_bytes());
+    // tx_counter (byte 4) and rx_counter (byte 5) stay zero.
+    cmd
+}
+
+/// Enable or disable the ISO CAN-FD framing option.
+pub fn cmd_set_fd_iso(channel: u8, iso: bool) -> Command {
+    let opcode = if iso {
+        CMD_SET_EN_OPTION
+    } else {
+        CMD_CLR_DIS_OPTION
+    };
+    let mut cmd = command(channel, opcode);
+    cmd[2..4].copy_from_slice(&OPTION_CAN_FD_ISO.to_le_bytes());
+    cmd
+}
+
+/// Accept-all entry for one of the 64 standard-ID filter rows.
+pub fn cmd_filter_std_row(channel: u8, idx: u16, mask: u32) -> Command {
+    let mut cmd = command(channel, CMD_FILTER_STD);
+    cmd[2..4].copy_from_slice(&idx.to_le_bytes());
+    cmd[4..8].copy_from_slice(&mask.to_le_bytes());
+    cmd
+}
+
+/// Number of standard-ID filter rows (each row covers 32 consecutive IDs).
+pub const FILTER_STD_ROWS: u16 = 64;
+
+/// Build the commands accepting every standard CAN ID.
+pub fn cmd_filter_accept_all(channel: u8) -> Vec<Command> {
+    (0..FILTER_STD_ROWS)
+        .map(|idx| cmd_filter_std_row(channel, idx, 0xffff_ffff))
+        .collect()
+}
+
+/// Build the slow (nominal/arbitration) bit-timing command.
+pub fn cmd_timing_slow(channel: u8, t: &AdapterBitTiming) -> Command {
+    let mut cmd = command(channel, CMD_TIMING_SLOW);
+    cmd[2] = DEFAULT_ERROR_WARNING_LIMIT;
+    cmd[3] = ((t.sjw - 1) & 0x7f) as u8; // sjw_t, triple-sampling bit left clear
+    cmd[4] = ((t.tseg2 - 1) & 0x7f) as u8;
+    cmd[5] = ((t.tseg1 - 1) & 0xff) as u8;
+    cmd[6..8].copy_from_slice(&(((t.brp - 1) & 0x3ff) as u16).to_le_bytes());
+    cmd
+}
+
+/// Build the fast (CAN-FD data phase) bit-timing command.
+pub fn cmd_timing_fast(channel: u8, t: &AdapterBitTiming) -> Command {
+    let mut cmd = command(channel, CMD_TIMING_FAST);
+    // byte 2 unused
+    cmd[3] = ((t.sjw - 1) & 0xf) as u8;
+    cmd[4] = ((t.tseg2 - 1) & 0xf) as u8;
+    cmd[5] = ((t.tseg1 - 1) & 0x1f) as u8;
+    cmd[6..8].copy_from_slice(&(((t.brp - 1) & 0x3ff) as u16).to_le_bytes());
+    cmd
+}
+
+/// Encode one CAN frame into a transmit message record.
+///
+/// `brs` requests bitrate switching for CAN-FD frames. `LOOPED_BACK` is always
+/// set so the device echoes the frame back once it has been transmitted on the
+/// bus, which the async layer uses as the ACK signal.
+pub fn encode_tx_frame(frame: &Frame, brs: bool) -> Result<Vec<u8>, Error> {
+    let dlc = len_to_dlc(frame.data.len())?;
+
+    let mut flags = FLAG_LOOPED_BACK;
+    let id: u32 = match frame.id {
+        Identifier::Extended(id) => {
+            flags |= FLAG_EXT_ID;
+            id
+        }
+        Identifier::Standard(id) => id,
+    };
+
+    if frame.fd {
+        flags |= FLAG_EXT_DATA_LEN;
+        if brs {
+            flags |= FLAG_BITRATE_SWITCH;
+        }
+    }
+
+    let msg_size = align4(TX_MSG_HEADER_SIZE + frame.data.len());
+    let mut buf = vec![0u8; msg_size];
+
+    buf[0..2].copy_from_slice(&(msg_size as u16).to_le_bytes());
+    buf[2..4].copy_from_slice(&MSG_CAN_TX.to_le_bytes());
+    // bytes 4..12: tag (unused, left zero)
+    buf[12] = (frame.bus & 0xf) | (dlc << 4); // channel_dlc
+                                              // byte 13: client (echo index, unused)
+    buf[14..16].copy_from_slice(&flags.to_le_bytes());
+    buf[16..20].copy_from_slice(&id.to_le_bytes());
+    buf[20..20 + frame.data.len()].copy_from_slice(&frame.data);
+
+    Ok(buf)
+}
+
+/// Parse a buffer of received message records into CAN frames.
+///
+/// Non-CAN records (status, error, calibration, ...) are skipped. Parsing stops
+/// at the first zero-size record (end of list) or when a record would run past
+/// the end of the buffer. Returns the parsed frames and the number of dropped
+/// frames reported by overrun records.
+pub fn parse_rx_buffer(data: &[u8]) -> (Vec<Frame>, u32) {
+    let mut frames = Vec::new();
+    let mut overruns = 0u32;
+    let mut off = 0;
+
+    while off + 4 <= data.len() {
+        let size = u16::from_le_bytes([data[off], data[off + 1]]) as usize;
+        if size == 0 {
+            break; // end of list marker
+        }
+        let msg_type = u16::from_le_bytes([data[off + 2], data[off + 3]]);
+
+        if size < 4 || off + size > data.len() {
+            break; // truncated / malformed record
+        }
+
+        match msg_type {
+            MSG_CAN_RX if size >= RX_MSG_HEADER_SIZE => {
+                let channel_dlc = data[off + 20];
+                let flags = u16::from_le_bytes([data[off + 22], data[off + 23]]);
+                let id = u32::from_le_bytes([
+                    data[off + 24],
+                    data[off + 25],
+                    data[off + 26],
+                    data[off + 27],
+                ]);
+
+                let dlc = channel_dlc >> 4;
+                let channel = channel_dlc & 0xf;
+                let fd = flags & FLAG_EXT_DATA_LEN != 0;
+                let rtr = flags & FLAG_RTR != 0;
+                let loopback = flags & FLAG_LOOPED_BACK != 0;
+
+                let id = if flags & FLAG_EXT_ID != 0 {
+                    Identifier::Extended(id & 0x1fff_ffff)
+                } else {
+                    Identifier::Standard(id & 0x7ff)
+                };
+
+                let payload = if rtr {
+                    Vec::new()
+                } else {
+                    let want = dlc_to_len(dlc, fd);
+                    let avail = size - RX_MSG_HEADER_SIZE;
+                    let n = want.min(avail);
+                    data[off + RX_MSG_HEADER_SIZE..off + RX_MSG_HEADER_SIZE + n].to_vec()
+                };
+
+                frames.push(Frame {
+                    bus: channel,
+                    id,
+                    data: payload,
+                    loopback,
+                    fd,
+                });
+            }
+            MSG_OVERRUN => overruns += 1,
+            _ => {} // status / error / calibration / unknown: ignore
+        }
+
+        off += align4(size);
+    }
+
+    (frames, overruns)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn timing(brp: u32, tseg1: u32, tseg2: u32, sjw: u32) -> AdapterBitTiming {
+        AdapterBitTiming {
+            brp,
+            tseg1,
+            tseg2,
+            sjw,
+            bitrate: 0,
+            sample_point: 0.0,
+        }
+    }
+
+    #[test]
+    fn opcode_channel_packs_index_and_opcode() {
+        assert_eq!(opcode_channel(0, CMD_TIMING_SLOW), 0x004);
+        assert_eq!(opcode_channel(1, CMD_NORMAL_MODE), 0x1002);
+        // Extended commands keep their opcode in the low bits.
+        assert_eq!(opcode_channel(0, CMD_CLOCK_SET), 0x080);
+    }
+
+    #[test]
+    fn timing_slow_subtracts_one_from_each_field() {
+        // brp=8, tseg1=15, tseg2=4, sjw=2 -> 500k @ 80MHz, sp 0.8
+        let cmd = cmd_timing_slow(0, &timing(8, 15, 4, 2));
+        assert_eq!(u16::from_le_bytes([cmd[0], cmd[1]]), 0x004);
+        assert_eq!(cmd[2], DEFAULT_ERROR_WARNING_LIMIT);
+        assert_eq!(cmd[3], 1); // sjw - 1
+        assert_eq!(cmd[4], 3); // tseg2 - 1
+        assert_eq!(cmd[5], 14); // tseg1 - 1
+        assert_eq!(u16::from_le_bytes([cmd[6], cmd[7]]), 7); // brp - 1
+    }
+
+    #[test]
+    fn timing_fast_subtracts_one_from_each_field() {
+        let cmd = cmd_timing_fast(0, &timing(4, 6, 3, 1));
+        assert_eq!(u16::from_le_bytes([cmd[0], cmd[1]]), 0x005);
+        assert_eq!(cmd[3], 0); // sjw - 1
+        assert_eq!(cmd[4], 2); // tseg2 - 1
+        assert_eq!(cmd[5], 5); // tseg1 - 1
+        assert_eq!(u16::from_le_bytes([cmd[6], cmd[7]]), 3); // brp - 1
+    }
+
+    #[test]
+    fn accept_all_filter_covers_every_standard_id() {
+        let rows = cmd_filter_accept_all(0);
+        assert_eq!(rows.len(), 2048 / 32);
+        for (i, row) in rows.iter().enumerate() {
+            assert_eq!(u16::from_le_bytes([row[0], row[1]]), CMD_FILTER_STD);
+            assert_eq!(u16::from_le_bytes([row[2], row[3]]), i as u16);
+            assert_eq!(
+                u32::from_le_bytes([row[4], row[5], row[6], row[7]]),
+                0xffff_ffff
+            );
+        }
+    }
+
+    #[test]
+    fn encode_standard_frame_sets_looped_back() {
+        let frame = Frame::new(0, Identifier::Standard(0x123), &[1, 2, 3, 4, 5, 6, 7, 8]).unwrap();
+        let buf = encode_tx_frame(&frame, false).unwrap();
+
+        assert_eq!(buf.len(), align4(TX_MSG_HEADER_SIZE + 8));
+        assert_eq!(u16::from_le_bytes([buf[0], buf[1]]), buf.len() as u16);
+        assert_eq!(u16::from_le_bytes([buf[2], buf[3]]), MSG_CAN_TX);
+        assert_eq!(buf[12], 8 << 4); // dlc 8, channel 0
+        let flags = u16::from_le_bytes([buf[14], buf[15]]);
+        assert_eq!(flags & FLAG_LOOPED_BACK, FLAG_LOOPED_BACK);
+        assert_eq!(flags & FLAG_EXT_ID, 0);
+        assert_eq!(
+            u32::from_le_bytes([buf[16], buf[17], buf[18], buf[19]]),
+            0x123
+        );
+        assert_eq!(&buf[20..28], &[1, 2, 3, 4, 5, 6, 7, 8]);
+    }
+
+    #[test]
+    fn encode_extended_fd_frame_sets_flags() {
+        let frame = Frame::new(0, Identifier::Extended(0x1234), &[0xAA; 16]).unwrap();
+        assert!(frame.fd);
+        let buf = encode_tx_frame(&frame, true).unwrap();
+
+        let flags = u16::from_le_bytes([buf[14], buf[15]]);
+        assert_eq!(flags & FLAG_EXT_ID, FLAG_EXT_ID);
+        assert_eq!(flags & FLAG_EXT_DATA_LEN, FLAG_EXT_DATA_LEN);
+        assert_eq!(flags & FLAG_BITRATE_SWITCH, FLAG_BITRATE_SWITCH);
+        // dlc for 16 bytes is 0xA
+        assert_eq!(buf[12] >> 4, 0xA);
+    }
+
+    #[test]
+    fn encode_rejects_invalid_length() {
+        let frame = Frame {
+            bus: 0,
+            id: Identifier::Standard(0x1),
+            data: vec![0; 9], // 9 is not a valid CAN length
+            loopback: false,
+            fd: false,
+        };
+        assert!(matches!(
+            encode_tx_frame(&frame, false),
+            Err(Error::MalformedFrame)
+        ));
+    }
+
+    /// Build a received CAN record the way the device would, for round-trip tests.
+    fn build_rx_record(frame: &Frame) -> Vec<u8> {
+        let dlc = len_to_dlc(frame.data.len()).unwrap();
+        let size = align4(RX_MSG_HEADER_SIZE + frame.data.len());
+        let mut buf = vec![0u8; size];
+
+        let mut flags = 0u16;
+        if frame.loopback {
+            flags |= FLAG_LOOPED_BACK;
+        }
+        let id: u32 = match frame.id {
+            Identifier::Extended(id) => {
+                flags |= FLAG_EXT_ID;
+                id
+            }
+            Identifier::Standard(id) => id,
+        };
+        if frame.fd {
+            flags |= FLAG_EXT_DATA_LEN;
+        }
+
+        buf[0..2].copy_from_slice(&(size as u16).to_le_bytes());
+        buf[2..4].copy_from_slice(&MSG_CAN_RX.to_le_bytes());
+        buf[20] = (frame.bus & 0xf) | (dlc << 4);
+        buf[22..24].copy_from_slice(&flags.to_le_bytes());
+        buf[24..28].copy_from_slice(&id.to_le_bytes());
+        buf[28..28 + frame.data.len()].copy_from_slice(&frame.data);
+        buf
+    }
+
+    #[test]
+    fn decode_single_standard_frame() {
+        let frame = Frame::new(0, Identifier::Standard(0x123), &[1, 2, 3, 4, 5, 6, 7, 8]).unwrap();
+        let record = build_rx_record(&frame);
+
+        let (frames, overruns) = parse_rx_buffer(&record);
+        assert_eq!(overruns, 0);
+        assert_eq!(frames.len(), 1);
+        assert_eq!(frames[0], frame);
+    }
+
+    #[test]
+    fn decode_multiple_records_and_stops_at_terminator() {
+        let f1 = Frame::new(0, Identifier::Standard(0x100), &[0xDE, 0xAD]).unwrap();
+        let f2 = Frame::new(0, Identifier::Extended(0x1abcd), &[0xBE, 0xEF, 0x00, 0x11]).unwrap();
+
+        let mut buf = build_rx_record(&f1);
+        buf.extend_from_slice(&build_rx_record(&f2));
+        buf.extend_from_slice(&[0u8; 4]); // zero terminator
+        buf.extend_from_slice(&[0xAA; 8]); // garbage after terminator, must be ignored
+
+        let (frames, _) = parse_rx_buffer(&buf);
+        assert_eq!(frames, vec![f1, f2]);
+    }
+
+    #[test]
+    fn decode_marks_loopback_frames() {
+        let mut frame = Frame::new(0, Identifier::Standard(0x321), &[0xCA, 0xFE]).unwrap();
+        frame.loopback = true;
+        let record = build_rx_record(&frame);
+
+        let (frames, _) = parse_rx_buffer(&record);
+        assert_eq!(frames.len(), 1);
+        assert!(frames[0].loopback);
+        assert_eq!(frames[0], frame);
+    }
+
+    #[test]
+    fn encode_decode_round_trip() {
+        let frames = vec![
+            Frame::new(0, Identifier::Standard(0x123), &[1, 2, 3, 4, 5, 6, 7, 8]).unwrap(),
+            Frame::new(0, Identifier::Extended(0x1234), &[0xAA; 8]).unwrap(),
+            Frame::new(0, Identifier::Standard(0x0), &[]).unwrap(),
+            Frame::new(0, Identifier::Extended(0x18DAF110), &[0u8; 64]).unwrap(),
+        ];
+
+        for frame in frames {
+            // Encode as TX, then re-shape into the RX layout the device echoes back.
+            let tx = encode_tx_frame(&frame, true).unwrap();
+            assert_eq!(u16::from_le_bytes([tx[2], tx[3]]), MSG_CAN_TX);
+
+            let mut echo = frame.clone();
+            echo.loopback = true;
+            let record = build_rx_record(&echo);
+            let (decoded, _) = parse_rx_buffer(&record);
+            assert_eq!(decoded.len(), 1);
+            assert_eq!(decoded[0], echo);
+        }
+    }
+
+    #[test]
+    fn decode_truncated_record_is_ignored() {
+        let frame = Frame::new(0, Identifier::Standard(0x123), &[1, 2, 3, 4, 5, 6, 7, 8]).unwrap();
+        let mut record = build_rx_record(&frame);
+        record.truncate(record.len() - 4); // cut off part of the payload
+
+        let (frames, _) = parse_rx_buffer(&record);
+        assert!(frames.is_empty());
+    }
+}

--- a/tests/adapter_tests.rs
+++ b/tests/adapter_tests.rs
@@ -28,6 +28,15 @@ fn panda_bitrate_config() -> automotive::can::bitrate::BitrateConfig {
         .unwrap()
 }
 
+#[cfg(feature = "test-peak")]
+fn peak_bitrate_config() -> automotive::can::bitrate::BitrateConfig {
+    automotive::can::bitrate::BitrateBuilder::new::<automotive::peak::Peak>()
+        .bitrate(500_000)
+        .sample_point(0.8)
+        .build()
+        .unwrap()
+}
+
 #[cfg(feature = "test-vector")]
 fn vector_bitrate_config() -> automotive::can::bitrate::BitrateConfig {
     automotive::can::bitrate::BitrateBuilder::new::<automotive::vector::VectorCan>()
@@ -174,6 +183,22 @@ async fn vector_bulk_send_async() {
     let vector =
         automotive::vector::VectorCan::new_async(0, Some(vector_bitrate_config())).unwrap();
     bulk_send(&vector).await;
+}
+
+#[cfg(feature = "test-peak")]
+#[test]
+#[serial_test::serial]
+fn peak_bulk_send_sync() {
+    let mut peak = automotive::peak::Peak::new(peak_bitrate_config()).unwrap();
+    bulk_send_sync(&mut peak);
+}
+
+#[cfg(feature = "test-peak")]
+#[tokio::test]
+#[serial_test::serial]
+async fn peak_bulk_send_async() {
+    let peak = automotive::peak::Peak::new_async(peak_bitrate_config()).unwrap();
+    bulk_send(&peak).await;
 }
 
 #[cfg(feature = "test-socketcan")]


### PR DESCRIPTION
Implements a raw-USB (rusb) CAN adapter for the PEAK PCAN-USB FD family, speaking the uCAN command/message protocol directly over the USB bulk endpoints without the in-kernel driver or SocketCAN. Supports classic CAN and CAN-FD with full nominal and data-phase bit-timing control via BitrateBuilder, and uses CanAdapter::buffer_size for hardware flow control.

Adds scripts/peak_usb_unbind.sh to detach the kernel driver so the device can be driven over raw USB, wires the adapter into get_adapter(), and adds the peak bulk stress tests behind the test-peak feature.